### PR TITLE
chore: 구동 환경이 local인 경우 embedded-redis 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.signal:embedded-redis:0.9.1'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/aegis/server/global/config/EmbeddedRedisConfig.java
+++ b/src/main/java/aegis/server/global/config/EmbeddedRedisConfig.java
@@ -1,0 +1,36 @@
+package aegis.server.global.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+@Slf4j
+@Configuration
+@Profile({"local"})
+public class EmbeddedRedisConfig {
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        redisServer = new RedisServer(6379);
+        try {
+            redisServer.start();
+        } catch (Exception e) {
+            log.error("Embedded Redis 시작 실패: ", e);
+        }
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username:
+      password:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      username: ${REDIS_USERNAME}
+      password: ${REDIS_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: local
   application:
     name: aegis-server
   security:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,12 +12,6 @@ spring:
               - email
               - profile
               - openid
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-      username: ${REDIS_USERNAME}
-      password: ${REDIS_PASSWORD}
   session:
     redis:
       namespace: "aegis:session"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 로컬 및 프로덕션 환경에서 Redis 구성 추가
	- 로컬 개발을 위한 내장 Redis 서버 지원

- **구성 변경**
	- 빌드 종속성에 `embedded-redis` 라이브러리 추가
	- 로컬 및 프로덕션 프로필에 대한 Redis 연결 설정 구성
	- 기본 프로필을 로컬로 설정

- **기술적 개선**
	- 환경별 Redis 구성 관리
	- 동적 환경 변수를 통한 프로덕션 Redis 연결 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->