### PR TITLE
test: 거래 내역 테스트를 시스템 현재 시각에 의존적이지 않게 수정

### DIFF
--- a/src/main/java/aegis/server/domain/bank/service/parser/IbkTransactionParser.java
+++ b/src/main/java/aegis/server/domain/bank/service/parser/IbkTransactionParser.java
@@ -56,8 +56,11 @@ public class IbkTransactionParser implements TransactionParser {
                 DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")
         );
 
-        // 현재가 1월이고 거래가 12월이면 작년 거래
-        LocalDateTime transactionTime = (currentTime.getMonthValue() == 1 && parsedTime.getMonthValue() == 12)
+        // IBK의 경우 거래 내역에 년도 정보가 없으므로
+        // 12/31 23:59라고 적힌 거래가 그 다음 년도에 서버에서 파싱되면
+        // Y년 12월 31일 23시 59분으로 파싱되야 할 것이, Y+1년 12월 31일 23시 59분으로 파싱됨
+        // 따라서 파싱된 시각이 현재 시각보다 미래라면 작년으로 간주
+        LocalDateTime transactionTime = parsedTime.isAfter(currentTime)
                 ? parsedTime.minusYears(1)
                 : parsedTime;
 

--- a/src/test/java/aegis/server/domain/bank/service/parser/IbkTransactionParserTest.java
+++ b/src/test/java/aegis/server/domain/bank/service/parser/IbkTransactionParserTest.java
@@ -16,13 +16,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class IbkTransactionParserTest {
 
+    private final int currentYear = 2024;
     private IbkTransactionParser parser;
     private ZoneId timeZone;
 
     @BeforeEach
     void setUp() {
         timeZone = ZoneId.of("Asia/Seoul");
-        Clock clock = Clock.system(timeZone);
+        Clock clock = Clock.fixed(
+                LocalDateTime
+                        .of(currentYear, 12, 17, 14, 30)
+                        .atZone(timeZone)
+                        .toInstant(),
+                timeZone
+        );
         parser = new IbkTransactionParser(clock);
     }
 
@@ -44,7 +51,7 @@ class IbkTransactionParserTest {
         assertThat(transaction.getName()).isEqualTo("홍길동");
         assertThat(transaction.getBalance()).isEqualTo(150000);
 
-        String expectedTimeStr = LocalDateTime.now().getYear() + "/12/17 14:30";
+        String expectedTimeStr = currentYear + "/12/17 14:30";
         LocalDateTime expectedTime = LocalDateTime.parse(
                 expectedTimeStr,
                 DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")
@@ -59,7 +66,7 @@ class IbkTransactionParserTest {
         String log = """
                 [출금] 30000원 ATM출금
                 982-******-01-017
-                12/17 15:30 /잔액 120000원""";
+                12/17 14:30 /잔액 120000원""";
 
         // when
         Transaction transaction = parser.parse(log);
@@ -70,7 +77,7 @@ class IbkTransactionParserTest {
         assertThat(transaction.getName()).isEqualTo("ATM출금");
         assertThat(transaction.getBalance()).isEqualTo(120000);
 
-        String expectedTimeStr = LocalDateTime.now().getYear() + "/12/17 15:30";
+        String expectedTimeStr = currentYear + "/12/17 14:30";
         LocalDateTime expectedTime = LocalDateTime.parse(
                 expectedTimeStr,
                 DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 거래 시간 파싱 로직 개선
	- 연도 정보가 없는 거래 로그에 대한 처리 강화
	- 현재 시간 기준 미래 거래에 대한 연도 자동 조정 기능 추가

- **테스트**
	- 고정된 시계(Clock) 사용으로 테스트 일관성 향상
	- 연도 경계 테스트 케이스 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->