### PR TITLE
fix: `@RequestBody`가 없어 멤버 수정이 이뤄지지 않던 문제 해결

### DIFF
--- a/src/main/java/aegis/server/domain/member/controller/MemberController.java
+++ b/src/main/java/aegis/server/domain/member/controller/MemberController.java
@@ -29,12 +29,11 @@ public class MemberController {
 
 
     @PostMapping
-    public ResponseEntity<?> updateMember(
+    public ResponseEntity<Void> updateMember(
             @LoginUser SessionUser sessionUser,
-            @Validated MemberUpdateRequest request
+            @Validated @RequestBody MemberUpdateRequest request
     ) {
         memberService.updateMember(sessionUser, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
-
 }

--- a/src/main/java/aegis/server/domain/member/service/MemberService.java
+++ b/src/main/java/aegis/server/domain/member/service/MemberService.java
@@ -43,5 +43,4 @@ public class MemberService {
                 request.getSemester()
         );
     }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: local
   application:
     name: aegis-server
+  jackson:
+    property-naming-strategy: SNAKE_CASE
   security:
     oauth2:
       client:
@@ -17,7 +19,7 @@ spring:
   session:
     redis:
       namespace: "aegis:session"
-    timeout: 1800
+    timeout: 18000
 
 bank:
   type: ibk


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 없음

- **구성 변경**
	- Jackson 직렬화 전략을 스네이크 케이스로 변경
	- Redis 세션 타임아웃 시간을 18000초로 연장

- **기타 변경**
	- 회원 업데이트 메서드의 반환 타입 및 요청 본문 처리 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->