### PR TITLE
refactor: 가입 단계에서 사용자를 구분하는 값으로 sub 값 사용

### DIFF
--- a/.github/workflows/pr_gradle_check.yml
+++ b/.github/workflows/pr_gradle_check.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  check-and-test:
+  check:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,4 +29,4 @@ jobs:
           add-job-summary-as-pr-comment: always
 
       - name: Run Gradle Check
-        run: ./gradlew clean check --configuration-cache
+        run: ./gradlew check --configuration-cache

--- a/src/main/java/aegis/server/domain/member/domain/Member.java
+++ b/src/main/java/aegis/server/domain/member/domain/Member.java
@@ -15,6 +15,8 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
+    private String oidcId;
+
     private String email;
 
     private String name;
@@ -43,8 +45,9 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    public static Member createGuestMember(String email, String name) {
+    public static Member createGuestMember(String oidcId, String email, String name) {
         return Member.builder()
+                .oidcId(oidcId)
                 .email(email)
                 .name(name)
                 .role(Role.GUEST)

--- a/src/main/java/aegis/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/aegis/server/domain/member/repository/MemberRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findByOidcId(String oidcId);
 }

--- a/src/main/java/aegis/server/domain/survey/domain/InterestField.java
+++ b/src/main/java/aegis/server/domain/survey/domain/InterestField.java
@@ -29,7 +29,7 @@ public enum InterestField {
     APP("앱"),
     DEVOPS("DevOps"),
     AI("인공지능"),
-    NOTSURE("아직 잘 모르겠어요"),
+    NOT_SURE("아직 잘 모르겠어요"),
     ETC("기타");
 
     private final String description;

--- a/src/main/java/aegis/server/domain/survey/domain/Survey.java
+++ b/src/main/java/aegis/server/domain/survey/domain/Survey.java
@@ -23,17 +23,18 @@ public class Survey {
 
     @Id
     @GeneratedValue
-    @Column(name="survey_id")
+    @Column(name = "survey_id")
     private Long id;
 
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="member_id")
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @ElementCollection
     @CollectionTable(name = "interests", joinColumns = @JoinColumn(name = "survey_id"))
     @Enumerated(EnumType.STRING)
+    @Builder.Default
     private Set<InterestField> interestFields = new HashSet<>();
 
     @ElementCollection
@@ -41,6 +42,7 @@ public class Survey {
     @MapKeyEnumerated(EnumType.STRING)
     @MapKeyColumn(name = "interest_field")
     @Column(name = "etc")
+    @Builder.Default
     private Map<InterestField, String> interestEtc = new HashMap<>();
 
     private String registrationReason;

--- a/src/main/java/aegis/server/domain/survey/dto/SurveyRequest.java
+++ b/src/main/java/aegis/server/domain/survey/dto/SurveyRequest.java
@@ -7,8 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -17,13 +15,14 @@ import java.util.Set;
 @AllArgsConstructor
 public class SurveyRequest {
 
-    private Set<InterestField> interestFields = new HashSet<>();
+    private Set<InterestField> interestFields;
 
     @Nullable
-    private Map<InterestField, String> interestEtc = new HashMap<>(); 
+    private Map<InterestField, String> interestEtc;
 
     @Size(min = 3)
     private String registrationReason;
+
     private String feedBack;
 
 }

--- a/src/main/java/aegis/server/domain/survey/service/SurveyService.java
+++ b/src/main/java/aegis/server/domain/survey/service/SurveyService.java
@@ -24,7 +24,7 @@ public class SurveyService {
 
     @Transactional
     public void save(SurveyRequest surveyRequest, SessionUser sessionUser) {
-        Member findMember = memberRepository.findByEmail(sessionUser.getEmail())
+        Member findMember = memberRepository.findById(sessionUser.getId())
                 .orElseThrow(() -> new IllegalStateException("구글 인증된 사용자가 존재하지 않습니다."));
 
         surveyRepository.findByMemberId(findMember.getId())

--- a/src/main/java/aegis/server/global/security/oidc/CustomOidcUserService.java
+++ b/src/main/java/aegis/server/global/security/oidc/CustomOidcUserService.java
@@ -27,6 +27,7 @@ public class CustomOidcUserService extends OidcUserService {
     }
 
     private Member findOrSave(OidcUser oidcUser) {
+        String oidcId = oidcUser.getSubject();
         String email = oidcUser.getEmail();
         String name = oidcUser.getFullName();
 
@@ -34,8 +35,8 @@ public class CustomOidcUserService extends OidcUserService {
             throw new OAuth2AuthenticationException("단국대학교 구성원만 로그인할 수 있습니다.");
         }
 
-        return memberRepository.findByEmail(email).orElseGet(
-                () -> memberRepository.save(Member.createGuestMember(email, name))
+        return memberRepository.findByOidcId(oidcId).orElseGet(
+                () -> memberRepository.save(Member.createGuestMember(oidcId, email, name))
         );
     }
 }

--- a/src/test/java/aegis/server/common/IntegrationTest.java
+++ b/src/test/java/aegis/server/common/IntegrationTest.java
@@ -40,7 +40,7 @@ public abstract class IntegrationTest {
     }
 
     protected Member createGuestMember() {
-        Member member = Member.createGuestMember("test@dankook.ac.kr", "테스트");
+        Member member = Member.createGuestMember("123456789012345678901", "test@dankook.ac.kr", "테스트");
         memberRepository.save(member);
         ReflectionTestUtils.setField(member, "email", "test" + member.getId() + "@dankook.ac.kr");
         ReflectionTestUtils.setField(member, "name", "테스트" + member.getId());

--- a/src/test/java/aegis/server/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/aegis/server/domain/member/service/MemberServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class MemberServiceTest {
 
+    private static final String TEST_OIDC_ID = "123456789012345678901";
     private static final String TEST_EMAIL = "test@dankook.ac.kr";
     private static final String TEST_NAME = "홍길동";
     private static final Long TEST_MEMBER_ID = 1L;
@@ -35,7 +36,7 @@ public class MemberServiceTest {
     private MemberService memberService;
 
     private Member createTestMember() {
-        Member member = Member.createGuestMember(TEST_EMAIL, TEST_NAME);
+        Member member = Member.createGuestMember(TEST_OIDC_ID, TEST_EMAIL, TEST_NAME);
         ReflectionTestUtils.setField(member, "id", TEST_MEMBER_ID);
         return member;
     }

--- a/src/test/java/aegis/server/domain/survey/service/SurveyServiceTest.java
+++ b/src/test/java/aegis/server/domain/survey/service/SurveyServiceTest.java
@@ -129,7 +129,7 @@ class SurveyServiceTest {
     void 모든_설문_조회() {
         // given
         Member member1 = Member.createGuestMember("123456789012345678901", "test1@dankook.ac.kr", "테스트1");
-        Member member2 = Member.createGuestMember("123456789012345678901", "test2@dankook.ac.kr", "테스트2");
+        Member member2 = Member.createGuestMember("123456789012345678902", "test2@dankook.ac.kr", "테스트2");
         ReflectionTestUtils.setField(member1, "id", 1L);
         ReflectionTestUtils.setField(member2, "id", 2L);
 

--- a/src/test/java/aegis/server/domain/survey/service/SurveyServiceTest.java
+++ b/src/test/java/aegis/server/domain/survey/service/SurveyServiceTest.java
@@ -1,11 +1,5 @@
 package aegis.server.domain.survey.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import aegis.server.domain.member.domain.Member;
 import aegis.server.domain.member.repository.MemberRepository;
 import aegis.server.domain.survey.domain.InterestField;
@@ -14,17 +8,20 @@ import aegis.server.domain.survey.dto.SurveyRequest;
 import aegis.server.domain.survey.repository.SurveyRepository;
 import aegis.server.global.security.dto.SessionUser;
 import aegis.server.global.security.oidc.UserAuthInfo;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SurveyServiceTest {
@@ -40,7 +37,7 @@ class SurveyServiceTest {
     @Test
     void 새로운_설문_저장() {
         // given
-        Member member = Member.createGuestMember("test@dankook.ac.kr", "테스트");
+        Member member = Member.createGuestMember("123456789012345678901", "test@dankook.ac.kr", "테스트");
         ReflectionTestUtils.setField(member, "id", 1L);
 
         UserAuthInfo userAuthInfo = UserAuthInfo.from(member);
@@ -53,7 +50,7 @@ class SurveyServiceTest {
                 .feedBack("예시로 작년과는 이런 점이 달라졌으면 좋겠어요!")
                 .build();
 
-        when(memberRepository.findByEmail(sessionUser.getEmail()))
+        when(memberRepository.findById(sessionUser.getId()))
                 .thenReturn(Optional.of(member));
         when(surveyRepository.findByMemberId(member.getId()))
                 .thenReturn(Optional.empty());
@@ -68,7 +65,7 @@ class SurveyServiceTest {
     @Test
     void 기존_설문_업데이트() {
         // given
-        Member member = Member.createGuestMember("test@dankook.ac.kr", "테스트");
+        Member member = Member.createGuestMember("123456789012345678901", "test@dankook.ac.kr", "테스트");
         ReflectionTestUtils.setField(member, "id", 1L);
 
         UserAuthInfo userAuthInfo = UserAuthInfo.from(member);
@@ -88,7 +85,7 @@ class SurveyServiceTest {
                 .feedBack("새로운 피드백")
                 .build();
 
-        when(memberRepository.findByEmail(sessionUser.getEmail()))
+        when(memberRepository.findById(sessionUser.getId()))
                 .thenReturn(Optional.of(member));
         when(surveyRepository.findByMemberId(member.getId()))
                 .thenReturn(Optional.of(existingSurvey));
@@ -105,7 +102,7 @@ class SurveyServiceTest {
     @Test
     void 회원_ID로_설문_조회() {
         // given
-        Member member = Member.createGuestMember("test@dankook.ac.kr", "테스트");
+        Member member = Member.createGuestMember("123456789012345678901", "test@dankook.ac.kr", "테스트");
         ReflectionTestUtils.setField(member, "id", 1L);
 
         Survey survey = Survey.createSurvey(member, SurveyRequest.builder()
@@ -131,8 +128,8 @@ class SurveyServiceTest {
     @Test
     void 모든_설문_조회() {
         // given
-        Member member1 = Member.createGuestMember("test1@dankook.ac.kr", "테스트1");
-        Member member2 = Member.createGuestMember("test2@dankook.ac.kr", "테스트2");
+        Member member1 = Member.createGuestMember("123456789012345678901", "test1@dankook.ac.kr", "테스트1");
+        Member member2 = Member.createGuestMember("123456789012345678901", "test2@dankook.ac.kr", "테스트2");
         ReflectionTestUtils.setField(member1, "id", 1L);
         ReflectionTestUtils.setField(member2, "id", 2L);
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,3 +20,6 @@ spring:
             client-secret: test-client-secret
 key:
   tx-track-api: test-api-key
+
+client:
+  origin: https://join.dk-aegis.org


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
	- OIDC(OpenID Connect) 기반 사용자 인증 지원 추가
	- 사용자 식별 방식을 이메일에서 고유 식별자(OIDC ID)로 변경

- **개선 사항**
	- 멤버 조회 및 생성 로직 업데이트
	- 테스트 환경의 클라이언트 설정 확장

- **기술적 변경**
	- 멤버 도메인에 OIDC ID 필드 추가
	- 멤버 리포지토리 및 서비스 로직 수정
	- 설문 조사 도메인 필드에 기본값 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->