### PR TITLE
docs: 멤버 컨트롤러에 Swagger로 API 문서 추가

### DIFF
--- a/src/main/java/aegis/server/domain/member/controller/MemberController.java
+++ b/src/main/java/aegis/server/domain/member/controller/MemberController.java
@@ -5,8 +5,13 @@ import aegis.server.domain.member.dto.response.MemberResponse;
 import aegis.server.domain.member.service.MemberService;
 import aegis.server.global.security.annotation.LoginUser;
 import aegis.server.global.security.dto.SessionUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +24,20 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping
+    @Operation(
+            summary = "구글 로그인 성공시 기본 인적사항 페이지로 이동",
+            description = "session정보를 통해 MemberResponse를 생성, 현재 JoinProgress를 PERSONAL_INFORMATION로 변경",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "sessionUser를 통한 MemberResponse불러오기 성공",
+                            content = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = MemberResponse.class)
+                            )
+                    )
+            }
+    )
     public ResponseEntity<MemberResponse> getMember(
             @LoginUser SessionUser sessionUser
     ) {
@@ -27,6 +46,10 @@ public class MemberController {
     }
 
     @PostMapping
+    @Operation(
+            summary = "기본 인적사항 저장",
+            responses = {@ApiResponse(responseCode = "201", description = "기본 인적사항 저장 완료")}
+    )
     public ResponseEntity<Void> updateMember(
             @LoginUser SessionUser sessionUser,
             @Validated @RequestBody MemberUpdateRequest request

--- a/src/main/java/aegis/server/domain/member/service/MemberService.java
+++ b/src/main/java/aegis/server/domain/member/service/MemberService.java
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
	- 회원 관련 API 엔드포인트에 OpenAPI 주석 추가
	- `getMember` 및 `updateMember` 메서드의 API 문서 개선
	- 응답 상태 코드 및 JSON 콘텐츠 유형에 대한 명세 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->