### PR TITLE
chore: 여러 플랫폼을 지원하는 embedded-redis 패키지로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-    implementation 'org.signal:embedded-redis:0.9.1'
+    implementation 'com.github.codemonstur:embedded-redis:1.4.3'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/aegis/server/global/config/EmbeddedRedisConfig.java
+++ b/src/main/java/aegis/server/global/config/EmbeddedRedisConfig.java
@@ -27,7 +27,7 @@ public class EmbeddedRedisConfig {
     }
 
     @PreDestroy
-    public void stopRedis() {
+    public void stopRedis() throws IOException {
         if (redisServer != null) {
             redisServer.stop();
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **종속성 업데이트**
	- 내장 Redis 라이브러리 버전을 1.4.3으로 업그레이드
	- 라이브러리 그룹 ID를 `org.signal`에서 `com.github.codemonstur`로 변경

- **코드 변경**
	- `stopRedis()` 메서드에 `IOException` 예외 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->