### PR TITLE
feat: 디스코드 연동 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'com.github.codemonstur:embedded-redis:1.4.3'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
+    implementation 'net.dv8tion:JDA:5.2.2'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/aegis/server/domain/discord/controller/DiscordController.java
+++ b/src/main/java/aegis/server/domain/discord/controller/DiscordController.java
@@ -1,0 +1,28 @@
+package aegis.server.domain.discord.controller;
+
+import aegis.server.domain.discord.dto.response.DiscordVerificationCodeResponse;
+import aegis.server.domain.discord.service.DiscordService;
+import aegis.server.global.security.annotation.LoginUser;
+import aegis.server.global.security.dto.SessionUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/discord")
+@RequiredArgsConstructor
+public class DiscordController {
+
+    private final DiscordService discordService;
+
+    @PostMapping("/issue-verification-code")
+    public ResponseEntity<DiscordVerificationCodeResponse> getVerificationCode(@LoginUser SessionUser sessionUser) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(discordService.createVerificationCode(sessionUser));
+    }
+}

--- a/src/main/java/aegis/server/domain/discord/domain/DiscordVerification.java
+++ b/src/main/java/aegis/server/domain/discord/domain/DiscordVerification.java
@@ -1,0 +1,22 @@
+package aegis.server.domain.discord.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(value = "discord_verification", timeToLive = 300)
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiscordVerification {
+
+    @Id
+    private String code;
+
+    private Long memberId;
+
+    public static DiscordVerification of(String code, Long memberId) {
+        return new DiscordVerification(code, memberId);
+    }
+}

--- a/src/main/java/aegis/server/domain/discord/dto/response/DiscordVerificationCodeResponse.java
+++ b/src/main/java/aegis/server/domain/discord/dto/response/DiscordVerificationCodeResponse.java
@@ -1,0 +1,15 @@
+package aegis.server.domain.discord.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiscordVerificationCodeResponse {
+    private String code;
+
+    public static DiscordVerificationCodeResponse of(String code) {
+        return new DiscordVerificationCodeResponse(code);
+    }
+}

--- a/src/main/java/aegis/server/domain/discord/repository/DiscordVerificationRepository.java
+++ b/src/main/java/aegis/server/domain/discord/repository/DiscordVerificationRepository.java
@@ -1,0 +1,7 @@
+package aegis.server.domain.discord.repository;
+
+import aegis.server.domain.discord.domain.DiscordVerification;
+import org.springframework.data.repository.CrudRepository;
+
+public interface DiscordVerificationRepository extends CrudRepository<DiscordVerification, String> {
+}

--- a/src/main/java/aegis/server/domain/discord/service/DiscordService.java
+++ b/src/main/java/aegis/server/domain/discord/service/DiscordService.java
@@ -1,0 +1,54 @@
+package aegis.server.domain.discord.service;
+
+import aegis.server.domain.discord.domain.DiscordVerification;
+import aegis.server.domain.discord.dto.response.DiscordVerificationCodeResponse;
+import aegis.server.domain.discord.repository.DiscordVerificationRepository;
+import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.member.repository.MemberRepository;
+import aegis.server.global.security.dto.SessionUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Random;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DiscordService {
+
+    private final DiscordVerificationRepository discordVerificationRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public DiscordVerificationCodeResponse createVerificationCode(SessionUser sessionUser) {
+        Member member = memberRepository.findById(sessionUser.getId()).orElseThrow();
+        String code = generateUniqueCode();
+        discordVerificationRepository.save(DiscordVerification.of(code, member.getId()));
+
+        return DiscordVerificationCodeResponse.of(code);
+    }
+
+    @Transactional
+    public void verifyAndUpdateDiscordId(String verificationCode, String discordId) {
+        DiscordVerification discordVerification = discordVerificationRepository.findById(verificationCode).orElseThrow();
+
+        Member member = memberRepository.findById(discordVerification.getMemberId()).orElseThrow();
+
+        member.updateDiscordId(discordId);
+
+        discordVerificationRepository.delete(discordVerification);
+    }
+
+    private String generateUniqueCode() {
+        String code;
+        do {
+            code = generateRandomCode();
+        } while (discordVerificationRepository.existsById(code));
+        return code;
+    }
+
+    private String generateRandomCode() {
+        return String.format("%04d", new Random().nextInt(10000));
+    }
+}

--- a/src/main/java/aegis/server/domain/discord/service/listener/DiscordSlashCommandListener.java
+++ b/src/main/java/aegis/server/domain/discord/service/listener/DiscordSlashCommandListener.java
@@ -1,0 +1,39 @@
+package aegis.server.domain.discord.service.listener;
+
+import aegis.server.domain.discord.service.DiscordService;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordSlashCommandListener extends ListenerAdapter {
+
+    private final DiscordService discordService;
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!event.getName().equals("join")) return;
+
+        OptionMapping eventOption = event.getOption("code");
+        if (eventOption == null) {
+            event.reply("인증코드를 입력해주세요.").setEphemeral(true).queue();
+            return;
+        }
+        String verificationCode = eventOption.getAsString();
+        String discordId = event.getUser().getId();
+
+        try {
+            discordService.verifyAndUpdateDiscordId(verificationCode, discordId);
+            event.reply("디스코드 연동이 완료되었습니다.")
+                    .setEphemeral(true)
+                    .queue();
+        } catch (Exception e) {
+            event.reply("인증코드가 올바르지 않거나 만료되었습니다.")
+                    .setEphemeral(true)
+                    .queue();
+        }
+    }
+}

--- a/src/main/java/aegis/server/domain/member/domain/JoinProgress.java
+++ b/src/main/java/aegis/server/domain/member/domain/JoinProgress.java
@@ -6,5 +6,7 @@ public enum JoinProgress {
     SURVEY,
     EVERYTIME,
     DISCORD,
+    COUPON,
+    PAYMENT,
     COMPLETE
 }

--- a/src/main/java/aegis/server/domain/member/domain/Member.java
+++ b/src/main/java/aegis/server/domain/member/domain/Member.java
@@ -17,6 +17,8 @@ public class Member {
 
     private String oidcId;
 
+    private String discordId;
+
     private String email;
 
     private String name;
@@ -80,6 +82,10 @@ public class Member {
 
     public void updateJoinProgress(JoinProgress joinProgress) {
         this.joinProgress = joinProgress;
+    }
+
+    public void updateDiscordId(String discordId) {
+        this.discordId = discordId;
     }
 
 }

--- a/src/main/java/aegis/server/global/config/DiscordConfig.java
+++ b/src/main/java/aegis/server/global/config/DiscordConfig.java
@@ -1,0 +1,39 @@
+package aegis.server.global.config;
+
+import aegis.server.domain.discord.service.listener.DiscordSlashCommandListener;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class DiscordConfig {
+
+    @Value("${discord.token}")
+    private String token;
+
+    private final DiscordSlashCommandListener discordSlashCommandListener;
+
+    @Bean
+    public JDA jda() {
+        JDA jda = JDABuilder.createDefault(token)
+                .enableIntents(
+                        GatewayIntent.GUILD_MEMBERS,
+                        GatewayIntent.GUILD_MESSAGES,
+                        GatewayIntent.MESSAGE_CONTENT
+                )
+                .addEventListeners(discordSlashCommandListener)
+                .build();
+
+        jda.upsertCommand("join", "디스코드 연동 인증코드를 입력합니다.")
+                .addOption(OptionType.STRING, "code", "인증코드", true)
+                .queue();
+
+        return jda;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,8 @@ client:
 
 key:
   tx-track-api: ${TRANSACTION_TRACK_API_KEY}
+
+discord:
+  token: ${DISCORD_BOT_TOKEN}
+  guild-id: ${DISCORD_GUILD_ID}
+  complete-role-id: ${DISCORD_COMPLETE_ROLE_ID}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Discord 연동 기능 추가
	- 사용자가 Discord 인증 코드를 발급받고 계정을 연결할 수 있는 기능 구현
	- 결제 완료 시 자동으로 Discord 서버의 특정 역할 부여

- **의존성 추가**
	- JDA (Java Discord API) 라이브러리 버전 5.2.2 추가

- **기타 변경사항**
	- 회원 도메인에 Discord ID 필드 추가
	- 가입 진행 상태에 새로운 단계 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->